### PR TITLE
Connection to slanger fails with browser console message app key not found

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,3 +22,14 @@ Increase system limits (linux) with ulimit:
     # check/set your hard/soft limit on user processes (threads)
     ulimit -Hu
     ulimit -u 62823
+
+The connection to slanger may fail with a message that app key "foo" does not exist. Alter `app/assets/javascript/lib/pusher_connection.js.coffee`, add `enabledTransports: ['ws', wss']`:
+
+    pusher = new Pusher gon.pusher.key,
+      encrypted: gon.pusher.encrypted
+      wsHost: gon.pusher.wsHost
+      wsPort: gon.pusher.wsPort
+      wssPort: gon.pusher.wssPort
+      enabledTransports: ['ws', wss']
+
+    window.pusher = pusher


### PR DESCRIPTION
Firefox gives this message when attempting to connect:

`Pusher : Error : {"type":"WebSocketError","error":{"type":"PusherError","data":{"code":4001,"message":"Did you forget to specify the cluster when creating the Pusher instance?  App key foo does not exist in this cluster."}}}`

This is fixed by modifying `app/assets/javascript/lib/pusher_connection.js.coffee`.

Added this information to the tips section of `README.markdown`.